### PR TITLE
fix failing tests with recent Dist::Zilla

### DIFF
--- a/t/recommendedprereqs.t
+++ b/t/recommendedprereqs.t
@@ -3,7 +3,8 @@
 
 use strict;
 use warnings;
-use Test::More 0.88 tests => 4; # done_testing
+use version;
+use Test::More 0.88;
 
 use Test::DZil qw(Builder simple_ini);
 use Parse::CPAN::Meta;
@@ -22,12 +23,10 @@ $tzil->build;
 
 my $meta = Parse::CPAN::Meta->load_file($tzil->tempdir->file('build/META.yml'));
 
-SKIP: {
-  my $ver = $meta->{'meta-spec'}{version};
-  unless ($ver >= 2) {
-    skip "CPAN::Meta::Spec version $ver < 2.x", 4;
-  }
+my $ver = version->new($meta->{'meta-spec'}{version});
+diag "CPAN::Meta::Spec = $ver";
 
+if ($ver >= version->new('2')) { # See CPAN::Meta::Spec
   is_deeply(
     $meta->{prereqs}{runtime}{recommends},
     { 'Foo::Bar' => '1.00',
@@ -44,6 +43,17 @@ SKIP: {
     { 'Test::Other' => 0 },
     'test suggests'
   );
+} elsif ($ver >= version->new('1.4')) { 
+  is_deeply(
+    $meta->{recommends},
+    {
+      'Foo::Bar' => '1.00',
+      'Foo::Baz' => 0,
+    },
+    'runtime recommends'
+  );
+} else {
+  plan skip_all => "Unexpected CPAN::Meta::Spec version '$ver'";
 }
 
 done_testing;

--- a/t/recommendedprereqs.t
+++ b/t/recommendedprereqs.t
@@ -22,21 +22,28 @@ $tzil->build;
 
 my $meta = Parse::CPAN::Meta->load_file($tzil->tempdir->file('build/META.yml'));
 
-is_deeply(
-  $meta->{prereqs}{runtime}{recommends},
-  { 'Foo::Bar' => '1.00',
-    'Foo::Baz' => 0 },
-  'runtime recommends'
-);
+SKIP: {
+  my $ver = $meta->{'meta-spec'}{version};
+  unless ($ver >= 2) {
+    skip "CPAN::Meta::Spec version $ver < 2.x", 4;
+  }
 
-is($meta->{prereqs}{runtime}{suggests}, undef, 'runtime suggests');
-
-is($meta->{prereqs}{test}{recommends}, undef, 'test recommends');
-
-is_deeply(
-  $meta->{prereqs}{test}{suggests},
-  { 'Test::Other' => 0 },
-  'test suggests'
-);
+  is_deeply(
+    $meta->{prereqs}{runtime}{recommends},
+    { 'Foo::Bar' => '1.00',
+      'Foo::Baz' => 0 },
+    'runtime recommends'
+  );
+  
+  is($meta->{prereqs}{runtime}{suggests}, undef, 'runtime suggests');
+  
+  is($meta->{prereqs}{test}{recommends}, undef, 'test recommends');
+  
+  is_deeply(
+    $meta->{prereqs}{test}{suggests},
+    { 'Test::Other' => 0 },
+    'test suggests'
+  );
+}
 
 done_testing;


### PR DESCRIPTION
See this issue:
https://rt.cpan.org/Ticket/Display.html?id=116902

Dist::Zilla is how forcing the use of CPAN::Meta::Spec 1.4. The prereq tests in this module assume 2.x format.

I've modified the test to accommodate either 1.4 or 2. Please take a look at it because I'm not sure if it's too lax or not. There are fields in the 2.x format that don't seem to exist at all in 1.4, so I'm not testing for them.
