### PR TITLE
Fix warnings and failures from latest Dist::Zilla

### DIFF
--- a/lib/Dist/Zilla/Plugin/ArchiveRelease.pm
+++ b/lib/Dist/Zilla/Plugin/ArchiveRelease.pm
@@ -47,7 +47,7 @@ with 'Dist::Zilla::Role::BeforeRelease';
 with 'Dist::Zilla::Role::Releaser';
 with 'Dist::Zilla::Role::FilePruner';
 
-use Path::Class ();
+use Path::Tiny ();
 #---------------------------------------------------------------------
 
 =attr directory
@@ -87,7 +87,7 @@ sub directory
     $self->_set_directory($dir);
   } # end if $dir begins with ~
 
-  Path::Class::dir($dir)->absolute($self->zilla->root);
+  Path::Tiny::path($dir)->absolute($self->zilla->root)->stringify;
 } # end get_directory
 
 #---------------------------------------------------------------------
@@ -112,7 +112,7 @@ sub prune_files
   my $self = shift;
 
   my $root = $self->zilla->root;
-  my $dir  = $self->directory;
+  my $dir  = Path::Tiny::path($self->directory);
 
   if ($root->subsumes($dir)) {
     $dir      = $dir->relative($root);
@@ -129,7 +129,7 @@ sub before_release
 {
   my ($self, $tgz) = @_;
 
-  my $dir = $self->directory;
+  my $dir  = Path::Tiny::path($self->directory);
 
   # If the directory doesn't exist, create it:
   unless (-d $dir) {
@@ -140,7 +140,7 @@ sub before_release
   }
 
   # If the tarball has already been archived, abort:
-  my $file = $dir->file($tgz->basename);
+  my $file = $dir->child($tgz->basename);
 
   $self->log_fatal($self->pretty_path($file) . " already exists")
       if -e $file;
@@ -155,7 +155,7 @@ sub release
 
   chmod(0444, $tgz);
 
-  my $dest = $self->directory->file($tgz->basename);
+  my $dest = Path::Tiny::path($self->directory)->child($tgz->basename);
   my $destR = $self->pretty_path($dest);
 
   require File::Copy;

--- a/lib/Dist/Zilla/Role/ModuleInfo.pm
+++ b/lib/Dist/Zilla/Role/ModuleInfo.pm
@@ -25,7 +25,7 @@ use Moose::Role;
 use autodie ':io';
 use File::Temp 0.19 ();         # need newdir
 use Module::Metadata ();
-use Path::Class qw(dir file);
+use Path::Tiny qw(path);
 
 =head1 DEPENDENCIES
 
@@ -61,11 +61,11 @@ sub get_module_info
   # so we'll write the current contents to a temporary file:
 
   my $tempdirObject = File::Temp->newdir();
-  my $dir     = dir("$tempdirObject");
-  my $modPath = file($file->name);
+  my $dir     = path("$tempdirObject");
+  my $modPath = path($file->name);
 
   # Module::Metadata only cares about the basename of the file:
-  my $tempname = $dir->file($modPath->basename);
+  my $tempname = $dir->child($modPath->basename);
 
   open(my $temp, '>:raw', $tempname);
   print $temp Dist::Zilla->VERSION < 5 ? $file->content : $file->encoded_content;

--- a/t/arcrel.t
+++ b/t/arcrel.t
@@ -4,6 +4,7 @@
 use strict;
 use warnings;
 use Test::More 0.88 tests => 6; # done_testing
+use Path::Tiny qw/path/;
 
 use Test::DZil 'Builder';
 
@@ -79,10 +80,11 @@ sub new_tzil
 
   $tzil->release;
 
-  my $tarball = $tzil->root->file('releases/DZT-Sample-0.001.tar.gz');
+  my $tz_root = path($tzil->root);
+  my $tarball = $tz_root->child('releases/DZT-Sample-0.001.tar.gz');
   ok(-e $tarball, 'archived tarball');
   is($tarball->stat->mode & 0777, 0444, 'tarball is read-only');
-  ok((not -e $tzil->root->file('DZT-Sample-0.001.tar.gz')),
+  ok((not -e $tz_root->child('DZT-Sample-0.001.tar.gz')),
      'tarball was moved');
 }
 
@@ -94,7 +96,7 @@ sub new_tzil
   my $arcrel = $tzil->plugins_with(-Releaser)->[0];
 
   is($arcrel->directory,
-     Path::Class::dir(File::HomeDir->my_home, qw(some dir)),
+     path(File::HomeDir->my_home, qw(some dir)),
      '~ expansion');
 }
 

--- a/t/gitvercheck.t
+++ b/t/gitvercheck.t
@@ -19,7 +19,7 @@ BEGIN {
 use Test::DZil 'Builder';
 use File::pushd 'pushd';
 use File::Temp ();
-use Path::Class qw(dir file);
+use Path::Tiny qw(path);
 use Try::Tiny qw(try catch);
 
 my $stoppedRE = qr/Stopped because of errors/;
@@ -31,8 +31,8 @@ my $fakeHome   = File::Temp->newdir;
 $ENV{HOME}     = "$fakeHome"; # Don't want user's ~/.gitconfig to interfere
 
 my $tempdir    = File::Temp->newdir;
-my $gitRoot    = dir("$tempdir")->absolute;
-my $gitHistory = file("corpus/gitvercheck.git")->absolute;
+my $gitRoot    = path("$tempdir")->absolute;
+my $gitHistory = path("corpus/gitvercheck.git")->absolute;
 
 my $git;
 
@@ -59,7 +59,7 @@ sub edit
 {
   my ($file, $edit) = @_;
 
-  my $fn = $gitRoot->subdir("lib/DZT")->file("$file.pm");
+  my $fn = $gitRoot->child("lib/DZT/$file.pm");
 
   local $_ = do {
     local $/;
@@ -96,7 +96,7 @@ sub new_tzil
   # Something about the copy dzil makes seems to confuse git into
   # thinking files are modified when they aren't.
   # Run "git reset --mixed" in the source directory to unconfuse it:
-  Git::Wrapper->new( $tzil->tempdir->subdir("source")->stringify )
+  Git::Wrapper->new( path($tzil->tempdir)->child("source")->stringify )
               ->reset('--mixed');
 
   $tzil;
@@ -139,7 +139,7 @@ sub diag_log
   diag(map { "$_\n" } @{ $tzil->log_messages });
 
   {
-    my $wd = pushd($tzil->tempdir->subdir("source"));
+    my $wd = pushd(path($tzil->tempdir)->child("source"));
     diag(
       `git --version`,
       "git diff-index:\n", `git diff-index HEAD --name-only`,

--- a/t/recommendedprereqs.t
+++ b/t/recommendedprereqs.t
@@ -7,20 +7,21 @@ use Test::More 0.88 tests => 4; # done_testing
 
 use Test::DZil qw(Builder simple_ini);
 use Parse::CPAN::Meta;
+use Path::Tiny qw/path/;
 
 my $tzil = Builder->from_config(
   { dist_root => 'corpus/DZT' },
   {
     add_files => {
       'source/dist.ini' => simple_ini(qw(GatherDir RecommendedPrereqs),
-                                      [ MetaYAML => { version => 2 }]),
+                                      [ MetaJSON => { version => 2 }]),
     },
   },
 );
 
 $tzil->build;
 
-my $meta = Parse::CPAN::Meta->load_file($tzil->tempdir->file('build/META.yml'));
+my $meta = Parse::CPAN::Meta->load_file(path($tzil->tempdir)->child('build/META.json'));
 
 is_deeply(
   $meta->{prereqs}{runtime}{recommends},


### PR DESCRIPTION
This switches from Path::Class to Path::Tiny to avoid warnings from
Dist::Zilla.

It also updates t/recommendprereqs.t to generate a .json file rather
than a .yml file, as Dist::Zilla no longer allows generating YAML
with a META version of 2.
